### PR TITLE
For a 0.2.3 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJScientificTypes"
 uuid = "2e2323e0-db8b-457b-ae0d-bdfb3bc63afd"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -56,7 +56,7 @@ schema(X; kw...) = schema(X, Val(trait(X)); kw...)
 # Fallback
 schema(X, ::Val{:other}; kw...) =
     throw(ArgumentError("Cannot inspect the internal scitypes of "*
-                        "an object with trait `:other`."))
+                        "a non-tabular object. "))
 
 function schema(X, ::Val{:table}; kw...)
     sch    = Tables.schema(X)


### PR DESCRIPTION
Enhance the options for specifying features for scitytype coercion in tables when using `coerce` (#13)