### PR TITLE
Replace the warning about missing when using `coerce` with info

### DIFF
--- a/src/convention/coerce.jl
+++ b/src/convention/coerce.jl
@@ -99,13 +99,13 @@ function coerce(y::Arr{Any}, T::Type{<:Union{Missing,C}};
     op, num   = ifelse(C == Count, (_int, "65"), (float, "65.0"))
     has_chars = findfirst(e -> isa(e, Char), y) !== nothing
     if has_chars && verbosity > 0
-        @warn "Char value encountered, such value will be coerced according to the corresponding numeric value (e.g. 'A' to $num)."
+        @info "Char value encountered, such value will be coerced according to the corresponding numeric value (e.g. 'A' to $num)."
     end
     # broadcast the operation
     c = op.(y)
     # if the container type has  missing but not target, warn
     if (eltype(c) >: Missing) && !(T >: Missing) && verbosity > 0
-        @warn "Trying to coerce from `Any` to `$T` but encountered missing values.\nCoerced to `Union{Missing,$T}` instead."
+        @info "Trying to coerce from `Any` to `$T` but encountered missing values.\nCoerced to `Union{Missing,$T}` instead."
     end
     return c
 end
@@ -120,10 +120,10 @@ end
 function _coerce_missing_warn(::Type{T}, from::Type) where T
     T >: Missing && return
     if from == Any
-        @warn "Trying to coerce from `Any` to `$T` with categoricals.\n" *
+        @info "Trying to coerce from `Any` to `$T` with categoricals.\n" *
               "Coerced to `Union{Missing,$T}` instead."
     else
-        @warn "Trying to coerce from `$from` to `$T`.\n" *
+        @info "Trying to coerce from `$from` to `$T`.\n" *
               "Coerced to `Union{Missing,$T}` instead."
     end
     return

--- a/test/basic_tests.jl
+++ b/test/basic_tests.jl
@@ -151,30 +151,30 @@ end
 
     # missing values
     y_coerced = @test_logs(
-        (:warn, r"Trying to coerce from `Union{Missing,"),
+        (:info, r"Trying to coerce from `Union{Missing,"),
         coerce([4, 7, missing], Continuous))
     @test ismissing(y_coerced == [4.0, 7.0, missing])
     @test scitype_union(y_coerced) === Union{Missing,Continuous}
     y_coerced = @test_logs(
-        (:warn, r"Trying to coerce from `Any"),
+        (:info, r"Trying to coerce from `Any"),
         coerce(Any[4, 7.0, missing], Continuous))
     @test ismissing(y_coerced == [4.0, 7.0, missing])
     @test scitype_union(y_coerced) === Union{Missing,Continuous}
     y_coerced = @test_logs(
-        (:warn, r"Trying to coerce from `Union{Missing,"),
+        (:info, r"Trying to coerce from `Union{Missing,"),
         coerce([4.0, 7.0, missing], Count))
     @test ismissing(y_coerced == [4, 7, missing])
     @test scitype_union(y_coerced) === Union{Missing,Count}
     y_coerced = @test_logs(
-        (:warn, r"Trying to coerce from `Any"),
+        (:info, r"Trying to coerce from `Any"),
         coerce(Any[4, 7.0, missing], Count))
     @test ismissing(y_coerced == [4, 7, missing])
     @test scitype_union(y_coerced) === Union{Missing,Count}
     @test scitype_union(@test_logs(
-        (:warn, r"Trying to coerce from `Union{Missing,"),
+        (:info, r"Trying to coerce from `Union{Missing,"),
         coerce([:x, :y, missing], Multiclass))) === Union{Missing, Multiclass{2}}
     @test scitype_union(@test_logs(
-        (:warn, r"Trying to coerce from `Union{Missing,"),
+        (:info, r"Trying to coerce from `Union{Missing,"),
         coerce([:x, :y, missing], OrderedFactor))) === Union{Missing, OrderedFactor{2}}
     # non-missing Any vectors
     @test coerce(Any[4, 7],     Continuous) == [4.0, 7.0]
@@ -183,7 +183,7 @@ end
     # Finite conversions:
     @test scitype_union(coerce([:x, :y], Finite)) === Multiclass{2}
     @test scitype_union(@test_logs(
-        (:warn, r"Trying to coerce from `Union{Missing,"),
+        (:info, r"Trying to coerce from `Union{Missing,"),
         coerce([:x, :y, missing], Finite))) === Union{Missing, Multiclass{2}}
 
     # More finite conversions (to check resolution of #48):
@@ -210,7 +210,7 @@ end
 @testset "Real->OF" begin
     v = [0.1, 0.2, 0.2, 0.3, missing, 0.1]
     w = [0.1, 0.2, 0.2, 0.3, 0.1]
-    @test_logs((:warn, r"Trying to coerce from `Union{Missing,"),
+    @test_logs((:info, r"Trying to coerce from `Union{Missing,"),
                    global cv = coerce(v, OrderedFactor))
     cw = coerce(w, OrderedFactor)
     @test all(skipmissing(unique(cv)) .== [0.1, 0.2, 0.3])
@@ -220,9 +220,9 @@ end
 @testset "Any->MC" begin
     v1 = categorical(Any[1,2,1,2,1,missing,2])
     v2 = Any[collect("aksldjfalsdjkfslkjdfalksjdf")...]
-    @test_logs((:warn, r"Trying to coerce from `Any"),
+    @test_logs((:info, r"Trying to coerce from `Any"),
                global v1c = coerce(v1, Multiclass))
-    @test_logs((:warn, r"Trying to coerce from `Any"),
+    @test_logs((:info, r"Trying to coerce from `Any"),
                global v2c = coerce(v2, Multiclass))
     @test scitype_union(v1c) == Union{Missing,Multiclass{2}}
     @test scitype_union(v2c) == Multiclass{7}
@@ -239,7 +239,7 @@ end
     # normal behaviour
     v1 = categorical([1,2,1,2,1,2,missing])
     v2 = collect("aksldjfalsdjkfslkjdfalksjdf")
-    @test_logs((:warn, r"Trying to coerce from `Union"),
+    @test_logs((:info, r"Trying to coerce from `Union"),
                global v1c = coerce(v1, Multiclass))
     global v2c # otherwise julia complains...
     v2c = coerce(v2, Multiclass)

--- a/test/coverage.jl
+++ b/test/coverage.jl
@@ -12,7 +12,7 @@
 
     # coerce
     x = Any['a', 5]
-    @test (@test_logs (:warn, "Char value encountered, such value will be coerced according to the corresponding numeric value (e.g. 'A' to 65).") coerce(x, Count)) == [97, 5]
+    @test (@test_logs (:info, "Char value encountered, such value will be coerced according to the corresponding numeric value (e.g. 'A' to 65).") coerce(x, Count)) == [97, 5]
     x = categorical(['a','b','a','b'])
     @test coerce(x, Continuous) == [1.0,2.0,1.0,2.0]
     y = [missing, 1, 2]

--- a/test/extra_coercion.jl
+++ b/test/extra_coercion.jl
@@ -18,7 +18,7 @@ end
     cx = coerce(x, Union{Missing,Continuous})
     @test all(cx .=== [52.0, 15.0, 125.0, missing])
 
-    @test_logs (:warn, "Trying to coerce from `Union{Missing, String}` to `Count`.\nCoerced to `Union{Missing,Count}` instead.") coerce(x, Count)
+    @test_logs (:info, "Trying to coerce from `Union{Missing, String}` to `Count`.\nCoerced to `Union{Missing,Count}` instead.") coerce(x, Count)
 
     df = DataFrame(x=["1","2","3"], y=[2,3,4])
     coerce!(df, Textual=>Count)

--- a/test/extra_tests.jl
+++ b/test/extra_tests.jl
@@ -3,7 +3,7 @@ if VERSION ≥ v"1.3.0-"
       X = Tables.table(ones(1_000, 2))
       tmp = tempname()
       CSV.write(tmp, X)
-      data = CSV.DataFrame!(CSV.File(tmp, threaded=true))
+      data = CSV.DataFrame!(CSV.File(tmp))
       # data.Column1 and data.Column2 are Column2 (as of CSV 5.19)
       @test data.Column1 isa AbstractArray{<:AbstractFloat}
       dc = coerce(data, autotype(data, :discrete_to_continuous))

--- a/test/extra_tests.jl
+++ b/test/extra_tests.jl
@@ -3,9 +3,9 @@ if VERSION ≥ v"1.3.0-"
       X = Tables.table(ones(1_000, 2))
       tmp = tempname()
       CSV.write(tmp, X)
-      data = CSV.read(tmp, threaded=true)
+      data = CSV.DataFrame!(CSV.File(tmp, threaded=true))
       # data.Column1 and data.Column2 are Column2 (as of CSV 5.19)
-      @test_broken startswith("$(typeof(data.Column1))", "CSV.Column2")
+      @test data.Column1 isa AbstractArray{<:AbstractFloat}
       dc = coerce(data, autotype(data, :discrete_to_continuous))
       @test scitype(dc) == Table{AbstractArray{Continuous,1}}
       rm(tmp)

--- a/test/extra_tests.jl
+++ b/test/extra_tests.jl
@@ -5,7 +5,7 @@ if VERSION ≥ v"1.3.0-"
       CSV.write(tmp, X)
       data = CSV.read(tmp, threaded=true)
       # data.Column1 and data.Column2 are Column2 (as of CSV 5.19)
-      @test startswith("$(typeof(data.Column1))", "CSV.Column2")
+      @test_broken startswith("$(typeof(data.Column1))", "CSV.Column2")
       dc = coerce(data, autotype(data, :discrete_to_continuous))
       @test scitype(dc) == Table{AbstractArray{Continuous,1}}
       rm(tmp)


### PR DESCRIPTION
Generally a warning suggest the user may want to question the current approach, which isn't the case here - just that there are missing values, in case this wasn't noticed.