### PR TITLE
Ensure adherence to Tables.jl API

### DIFF
--- a/src/convention/scitype.jl
+++ b/src/convention/scitype.jl
@@ -32,9 +32,9 @@ end
 
 function ST.scitype(X, ::MLJ, ::Val{:table}; kw...)
     Xcol = Tables.columns(X)
-    col_names = propertynames(Xcol)
+    col_names = Tables.columnnames(Xcol)
     types = map(col_names) do name
-        scitype(getproperty(Xcol, name); kw...)
+        scitype(Tables.getcolumn(Xcol, name); kw...)
     end
     return Table{Union{types...}}
 end

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -60,6 +60,7 @@ schema(X, ::Val{:other}; kw...) =
 
 function schema(X, ::Val{:table}; kw...)
     sch    = Tables.schema(X)
+    sch === nothing && return nothing
     Xcol   = Tables.columntable(X)
     names  = sch.names
     types  = Tuple{sch.types...}

--- a/test/type_tests.jl
+++ b/test/type_tests.jl
@@ -29,6 +29,11 @@
     @test s1.scitypes == (Continuous, Count)
     @test s1.types == (Float64, Int64)
     @test s.nrows == 5
+    
+    #issue 47
+    X2 = ((x=rand(3), y=rand(3)),)
+    s2 = schema(X2)
+    @test s2 === nothing
 end
 
 @testset "csvfile" begin

--- a/test/type_tests.jl
+++ b/test/type_tests.jl
@@ -30,7 +30,6 @@
     @test s1.types == (Float64, Int64)
     @test s.nrows == 5
 end
-end
 
 @testset "csvfile" begin
     X = (x = rand(4), )

--- a/test/type_tests.jl
+++ b/test/type_tests.jl
@@ -21,6 +21,15 @@
     @test MLJScientificTypes._nrows(X) == 5
     @test MLJScientificTypes._nrows(()) == 0
     @test MLJScientificTypes._nrows((i for i in 1:7)) == 7
+    
+    # PR #61 "scitype checks for `Tables.DictColumn`"
+    X1 = Dict(:a=>rand(5), :b=>rand(Int, 5))
+    s1 = schema(X1)
+    @test info(X1) == schema(X1)
+    @test s1.scitypes == (Continuous, Count)
+    @test s1.types == (Float64, Int64)
+    @test s.nrows == 5
+end
 end
 
 @testset "csvfile" begin


### PR DESCRIPTION
1. For different tables types `Tables.getcolumns` and `Tables.columnnames` call underlying efficient methods. For example in the case of  `DataFrame` table type,  `Tables.columnnames(X)` calls `propertynames(X)`.

Also the previous code leads to weird behaviour as shown below
```julia
# master
julia> using MLJScientificTypes, Tables

julia> X = Dict(:a=>rand(5), :b=>rand(5))

Dict{Symbol,Array{Float64,1}} with 2 entries:
  :a => [0.517339, 0.184345, 0.723217, 0.0570972, 0.86573]
  :b => [0.880208, 0.494461, 0.78951, 0.851989, 0.8329]

julia> Tables.istable(X)
true

julia> scitype(X)
ERROR: UndefRefError: access to undefined reference
Stacktrace:

# This PR
julia> using MLJScientificTypes, Tables

julia> X = Dict(:a=>rand(5), :b=>rand(5))
Dict{Symbol,Array{Float64,1}} with 2 entries:
  :a => [0.510069, 0.161878, 0.453121, 0.755805, 0.755837]
  :b => [0.804957, 0.837796, 0.255365, 0.476521, 0.934868]

julia> Tables.istable(X)
true

julia> scitype(X)
Table{AbstractArray{Continuous,1}}
```
So I recommend strictly adhering to the **Tables.jl** API.

2. This PR also closes issue #47.