### PR TITLE
Import `info` stub from new package StatisticalTraits.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJScientificTypes"
 uuid = "2e2323e0-db8b-457b-ae0d-bdfb3bc63afd"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 PersistenceDiagramsBase = "b1ad91c1-539c-4ace-90bd-ea06abc420fa"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
+StatisticalTraits = "64bff920-2084-43da-a3e6-9bb72801c0c9"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
@@ -18,6 +19,7 @@ ColorTypes = "^0.9,^0.10"
 PersistenceDiagramsBase = "^0.1"
 PrettyTables = "^0.8,^0.9,^0.10"
 ScientificTypes = "^1.0"
+StatisticalTraits = "^0.1"
 Tables = "^1.0"
 julia = "1"
 

--- a/src/MLJScientificTypes.jl
+++ b/src/MLJScientificTypes.jl
@@ -2,7 +2,14 @@ module MLJScientificTypes
 
 # Dependencies
 using ScientificTypes
-using Tables, CategoricalArrays, ColorTypes, PersistenceDiagramsBase, PrettyTables, Dates
+using Tables
+using CategoricalArrays
+using ColorTypes
+using PersistenceDiagramsBase
+using PrettyTables
+using Dates
+
+import StatisticalTraits.info
 
 # re-exports from ScientificTypes
 export Scientific, Found, Unknown, Known, Finite, Infinite,
@@ -12,8 +19,11 @@ export Scientific, Found, Unknown, Known, Finite, Infinite,
     ScientificTime
 export scitype, scitype_union, elscitype, nonmissing, trait
 
+# re-export from StatisticalTraits
+export info
+
 # exports
-export coerce, coerce!, autotype, schema, info
+export coerce, coerce!, autotype, schema
 
 # -------------------------------------------------------------
 # Abbreviations

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -89,21 +89,5 @@ function Base.show(io::IO, ::MIME"text/plain", s::Schema)
     println(io, "_.nrows = $(s.nrows)")
 end
 
-"""
-    info(X)
-
-Return the metadata associated with some object `X`, typically a named tuple
-keyed on a set of object traits.
-
-*Notes on overloading:*: If the class of objects is detected by its type,
-`info` can be overloaded in the usual way.  If the class of objects is detected
-by the value of `ScientificTypes.trait(object)` - say if this value is
-`:some_symbol` - then one should define a method
-`info(object, ::Val{:some_symbol})`.
-"""
-info(X) = info(X, Val(trait(X)))
-
-# fallback
-info(X, ::Val{:other}) = nothing
-
+# overload StatisticalTraits function:
 info(X, ::Val{:table}) = schema(X)

--- a/test/coverage.jl
+++ b/test/coverage.jl
@@ -30,9 +30,6 @@
     @test c == categorical([1,2])
     @test !(eltype(c) >: Missing)
 
-    X = (1, 2, 3)
-    @test info(X) === nothing
-
     # increase autotype coverage
     M = MLJScientificTypes
     @test M.string_to_multiclass(String, ["a","b"], 0) == String

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test, ScientificTypes, MLJScientificTypes, Random
-using Tables, CategoricalArrays, CSV, DataFrames, ColorTypes, PersistenceDiagramsBase
+using Tables, CategoricalArrays, CSV, DataFrames
+using ColorTypes, PersistenceDiagramsBase
 using Dates
 
 const Arr  = AbstractArray


### PR DESCRIPTION
With `info` at `StatisticalTraits` it becomes available to other packages without them requiring MLJScientificTypes as a dependency.