### PR TITLE
fix bug in schema method

### DIFF
--- a/src/schema.jl
+++ b/src/schema.jl
@@ -65,13 +65,13 @@ function schema(X; kw...)
     sch === nothing && return nothing
     names = sch.names
     types = Tuple{sch.types...}
-    stypes = Tuple{[elscitype(getcolumn(cols, n); kw...) for n in names]...}
+    stypes = Tuple{[elscitype(Tables.getcolumn(cols, n); kw...) for n in names]...}
     return Schema(names, types, stypes, _nrows(cols))
 end
 
 function _nrows(cols)
     names = columnnames(cols)
-    return isempty(names) ? 0 : length(getcolumn(cols, names[1]))
+    return isempty(names) ? 0 : length(Tables.getcolumn(cols, names[1]))
 end
 
 function Base.show(io::IO, ::MIME"text/plain", s::Schema)

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -59,7 +59,7 @@ schema(X, ::Val{:other}; kw...) =
     throw(ArgumentError("Cannot inspect the internal scitypes of "*
                         "a non-tabular object. "))
 
-function schema(X; kw...)
+function schema(X, ::Val{:table}; kw...)
     cols = Tables.columns(X)
     sch = Tables.schema(cols)
     sch === nothing && return nothing

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -70,7 +70,7 @@ function schema(X; kw...)
 end
 
 function _nrows(cols)
-    names = columnnames(cols)
+    names = Tables.columnnames(cols)
     return isempty(names) ? 0 : length(Tables.getcolumn(cols, names[1]))
 end
 

--- a/test/type_tests.jl
+++ b/test/type_tests.jl
@@ -35,6 +35,7 @@
         y::Vector{V}
     end
     
+    Tables.istable(::MySchemalessTable) = true
     Tables.columnaccess(::Type{MySchemalessTable}) = true
     Tables.columns(t::MySchemalessTable) = t
 

--- a/test/type_tests.jl
+++ b/test/type_tests.jl
@@ -30,7 +30,15 @@
     @test s.nrows == 5
     
     #issue 47
-    X2 = ((x=rand(3), y=rand(3)),)
+    struct MySchemalessTable{U, V}
+        x::Vector{U}
+        y::Vector{V}
+    end
+    
+    Tables.columnaccess(::Type{MySchemalessTable}) = true
+    Tables.columns(t::MySchemalessTable) = t
+
+    X2 = MySchemalessTable(rand(3), rand(3))
     s2 = schema(X2)
     @test s2 === nothing
 end

--- a/test/type_tests.jl
+++ b/test/type_tests.jl
@@ -20,7 +20,6 @@
 
     @test MLJScientificTypes._nrows(X) == 5
     @test MLJScientificTypes._nrows(()) == 0
-    @test MLJScientificTypes._nrows((i for i in 1:7)) == 7
     
     # PR #61 "scitype checks for `Tables.DictColumn`"
     X1 = Dict(:a=>rand(5), :b=>rand(Int, 5))

--- a/test/type_tests.jl
+++ b/test/type_tests.jl
@@ -1,3 +1,12 @@
+struct MySchemalessTable{U, V}
+   x::Vector{U}
+   y::Vector{V}
+end
+    
+Tables.istable(::MySchemalessTable) = true
+Tables.columnaccess(::Type{MySchemalessTable}) = true
+Tables.columns(t::MySchemalessTable) = t
+
 @testset "Tables" begin
     X = (
         x = rand(5),
@@ -30,15 +39,6 @@
     @test s.nrows == 5
     
     #issue 47
-    struct MySchemalessTable{U, V}
-        x::Vector{U}
-        y::Vector{V}
-    end
-    
-    Tables.istable(::MySchemalessTable) = true
-    Tables.columnaccess(::Type{MySchemalessTable}) = true
-    Tables.columns(t::MySchemalessTable) = t
-
     X2 = MySchemalessTable(rand(3), rand(3))
     s2 = schema(X2)
     @test s2 === nothing


### PR DESCRIPTION
Fixes https://github.com/alan-turing-institute/MLJ.jl/issues/774
```julia
julia> using GeoStats, MLJScientificTypes
[ Info: Precompiling MLJScientificTypes [2e2323e0-db8b-457b-ae0d-bdfb3bc63afd]

julia> table = georef((col1=rand(10), col2=rand(Int, 10)))
10 GeoData{1,Float64}
  variables
    └─col1 (Float64)
    └─col2 (Int64)
  domain: 10 CartesianGrid{1,Float64}

julia> coerce(table, :col2 => Multiclass)
10 GeoData{1,Float64}
  variables
    └─col1 (Float64)
    └─col2 (CategoricalArrays.CategoricalValue{Int64, UInt32})
  domain: 10 GeometrySet{1,Float64}
```